### PR TITLE
Lobby presence sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,15 @@
 build/
 lobby.json
 server/zsilencer-lobby
+server/zsilencer-lobby.exe
 server/*.tmp
 *.o
 *.obj
+*~
+
+# Local-run artifacts produced by the client
+config.cfg
+PALETTECALC*.BIN
 
 # Terraform
 terraform/**/.terraform/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ zsilencer -s <lobbyaddr> <lobbyport> <gameid> <accountid>
   `127.0.0.1:517`. CI sets it to `silencer.hventura.com`; rebuild the
   client to point at a different lobby.
 - **Version string must match.** Client sets it at `src/game.cpp:31`
-  (`world.SetVersion("00023")`); the lobby's `-version` flag defaults
+  (`world.SetVersion("00024")`); the lobby's `-version` flag defaults
   to the same. Bump both together, or pass `-version ""` on the server
   to accept any client. `CMakeLists.txt` `CPACK_PACKAGE_VERSION` is
   installer metadata only — unrelated to the wire handshake.

--- a/server/client.go
+++ b/server/client.go
@@ -19,7 +19,12 @@ type Client struct {
 	accountID uint32
 	user      *User
 	channel   string
-	closed    bool
+	gameID    uint32 // 0 = main lobby; protected by Hub.mu once authed
+	// gameStatus: 0 = main lobby (gameID must be 0), 1 = pregame
+	// (game-specific lobby, connected to dedicated but match not started),
+	// 2 = playing. Protected by Hub.mu once authed.
+	gameStatus uint8
+	closed     bool
 }
 
 func (c *Client) displayName() string {
@@ -112,6 +117,8 @@ func (c *Client) handleFrame(frame []byte, expectedVersion string) error {
 		return c.handleUpgradeStat(r)
 	case opRegisterStats:
 		return c.handleRegisterStats(r)
+	case opSetGame:
+		return c.handleSetGame(r)
 	default:
 		log.Printf("[op] %s unknown opcode %d", c.conn.RemoteAddr(), op)
 	}
@@ -203,6 +210,19 @@ func (c *Client) sendDelGame(id uint32) {
 	c.send(w.b)
 }
 
+// action: 0 = add/upsert, 1 = remove.
+// status: 0 = lobby, 1 = pregame, 2 = playing.
+func (c *Client) sendPresence(action uint8, accountID, gameID uint32, status uint8, name string) {
+	w := &writer{}
+	w.u8(opPresence)
+	w.u8(action)
+	w.u32(accountID)
+	w.u32(gameID)
+	w.u8(status)
+	w.lenStr(name)
+	c.send(w.b)
+}
+
 func (c *Client) handleChat(r *reader) error {
 	channel, err := r.cstr(64)
 	if err != nil {
@@ -278,6 +298,22 @@ func (c *Client) handleUpgradeStat(r *reader) error {
 	if c.hub.store.UpgradeStat(c.accountID, agency, stat) {
 		c.send([]byte{opUpgradeStat})
 	}
+	return nil
+}
+
+func (c *Client) handleSetGame(r *reader) error {
+	if c.accountID == 0 {
+		return nil
+	}
+	gameID, err := r.u32()
+	if err != nil {
+		return err
+	}
+	status, err := r.u8()
+	if err != nil {
+		return err
+	}
+	c.hub.SetClientGame(c, gameID, status)
 	return nil
 }
 

--- a/server/hub.go
+++ b/server/hub.go
@@ -47,10 +47,37 @@ func (h *Hub) Join(c *Client) {
 	for _, g := range h.games {
 		games = append(games, g)
 	}
+	type snap struct {
+		acct   uint32
+		gameID uint32
+		status uint8
+		name   string
+	}
+	others := make([]snap, 0, len(h.clients))
+	peers := make([]*Client, 0, len(h.clients))
+	for other := range h.clients {
+		if other == c || other.accountID == 0 {
+			continue
+		}
+		others = append(others, snap{other.accountID, other.gameID, other.gameStatus, other.displayName()})
+		peers = append(peers, other)
+	}
+	selfSnap := snap{c.accountID, c.gameID, c.gameStatus, c.displayName()}
 	h.mu.Unlock()
+
 	for _, g := range games {
 		c.sendNewGame(1, g)
 	}
+	if c.accountID == 0 {
+		return
+	}
+	for _, o := range others {
+		c.sendPresence(0, o.acct, o.gameID, o.status, o.name)
+	}
+	for _, p := range peers {
+		p.sendPresence(0, selfSnap.acct, selfSnap.gameID, selfSnap.status, selfSnap.name)
+	}
+	c.sendPresence(0, selfSnap.acct, selfSnap.gameID, selfSnap.status, selfSnap.name)
 }
 
 func (h *Hub) Leave(c *Client) {
@@ -84,6 +111,7 @@ func (h *Hub) Leave(c *Client) {
 	for other := range h.clients {
 		others = append(others, other)
 	}
+	leavingAcct := c.accountID
 	h.mu.Unlock()
 
 	for _, id := range append(dropReady, dropPending...) {
@@ -93,6 +121,49 @@ func (h *Hub) Leave(c *Client) {
 		for _, other := range others {
 			other.sendDelGame(id)
 		}
+	}
+	if leavingAcct != 0 {
+		for _, other := range others {
+			other.sendPresence(1, leavingAcct, 0, 0, "")
+		}
+	}
+}
+
+// SetClientGame updates a client's gameID+status and announces the change.
+// status: 0 = main lobby, 1 = pregame (game-specific lobby), 2 = playing.
+// gameID=0 requires status=0. Unknown non-zero IDs are rejected.
+func (h *Hub) SetClientGame(c *Client, gameID uint32, status uint8) {
+	h.mu.Lock()
+	if c.accountID == 0 {
+		h.mu.Unlock()
+		return
+	}
+	if gameID == 0 {
+		status = 0
+	} else {
+		_, inGames := h.games[gameID]
+		_, inPending := h.pending[gameID]
+		if !inGames && !inPending {
+			h.mu.Unlock()
+			log.Printf("[hub] client %d set-game for unknown game %d; ignoring", c.accountID, gameID)
+			return
+		}
+		if status != 1 && status != 2 {
+			status = 1
+		}
+	}
+	c.gameID = gameID
+	c.gameStatus = status
+	acct := c.accountID
+	name := c.displayName()
+	peers := make([]*Client, 0, len(h.clients))
+	for other := range h.clients {
+		peers = append(peers, other)
+	}
+	h.mu.Unlock()
+
+	for _, p := range peers {
+		p.sendPresence(0, acct, gameID, status, name)
 	}
 }
 

--- a/server/main.go
+++ b/server/main.go
@@ -15,7 +15,7 @@ func main() {
 	addr := flag.String("addr", ":517", "listen address for TCP and UDP")
 	dbPath := flag.String("db", "lobby.json", "path to JSON user database")
 	motdPath := flag.String("motd", "", "path to MOTD file; empty = built-in default")
-	version := flag.String("version", "00023", "required client version; empty = accept any")
+	version := flag.String("version", "00024", "required client version; empty = accept any")
 	gameBinary := flag.String("game-binary", "../build/zsilencer", "path to the zsilencer binary (spawned per created game)")
 	publicAddr := flag.String("public-addr", "127.0.0.1", "host or IP clients (and dedicated servers) should use to reach this lobby")
 	flag.Parse()

--- a/server/protocol.go
+++ b/server/protocol.go
@@ -19,6 +19,8 @@ const (
 	opPing          = 9
 	opUpgradeStat   = 10
 	opRegisterStats = 11
+	opPresence      = 12
+	opSetGame       = 13
 )
 
 const maxFrame = 255

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -28,7 +28,7 @@
 #endif
 
 Game::Game() : renderer(world), screenbuffer(640, 480){
-	world.SetVersion("00023");
+	world.SetVersion("00024");
 	frames = 0;
 	fps = 0;
 	state = MAINMENU;
@@ -42,6 +42,9 @@ Game::Game() : renderer(world), screenbuffer(640, 480){
 	mappreviewinterface = 0;
 	modalinterface = 0;
 	sharedstate = 0;
+	currentlobbygameid = 0;
+	lastannouncedgameid = 0;
+	lastannouncedstatus = 0;
 	joininggame = false;
 	keynames[0] = "Move Up";
 	keynames[1] = "Move Down";
@@ -616,6 +619,26 @@ bool Game::Loop(void){
 
 bool Game::Tick(void){
 	ProcessInGameInterfaces();
+	if(!world.dedicatedserver.active){
+		if(world.lobby.state == Lobby::AUTHENTICATED){
+			// 0 = main lobby, 1 = pregame (game-specific lobby, waiting for
+			// match start), 2 = playing (gameplaystate == INGAME).
+			Uint32 targetgid = 0;
+			Uint8 targetstatus = 0;
+			if(currentlobbygameid != 0 && world.state == World::CONNECTED){
+				targetgid = currentlobbygameid;
+				targetstatus = (world.gameplaystate == World::INGAME) ? 2 : 1;
+			}
+			if(targetgid != lastannouncedgameid || targetstatus != lastannouncedstatus){
+				world.lobby.SendSetGame(targetgid, targetstatus);
+				lastannouncedgameid = targetgid;
+				lastannouncedstatus = targetstatus;
+			}
+		}else{
+			lastannouncedgameid = 0;
+			lastannouncedstatus = 0;
+		}
+	}
 	if(world.dedicatedserver.active && state != HOSTGAME){
 		if(world.dedicatedserver.nopeerstime >= 10 * 24){
 			world.dedicatedserver.SendHeartBeat(world, 2);
@@ -2200,6 +2223,7 @@ bool Game::LoadMap(const char * name){
 
 void Game::UnloadGame(void){
 	Audio::GetInstance().StopAll(200);
+	currentlobbygameid = 0;
 	for(int i = 0; i < sizeof(bgchannel) / sizeof(int); i++){
 		bgchannel[i] = -1;
 	}
@@ -3126,12 +3150,22 @@ Interface * Game::CreateChatInterface(void){
 	TextBox * textbox = (TextBox *)world.CreateObject(ObjectTypes::TEXTBOX);
 	textbox->x = 19;
 	textbox->y = 220;
-	textbox->width = 342;
+	textbox->width = 242;
 	textbox->height = 207;
 	textbox->res_bank = 133;
 	textbox->lineheight = 11;
 	textbox->fontwidth = 6;
 	textbox->bottomtotop = true;
+	TextBox * presencebox = (TextBox *)world.CreateObject(ObjectTypes::TEXTBOX);
+	presencebox->x = 267;
+	presencebox->y = 220;
+	presencebox->width = 110;
+	presencebox->height = 207;
+	presencebox->res_bank = 133;
+	presencebox->lineheight = 11;
+	presencebox->fontwidth = 6;
+	presencebox->bottomtotop = false;
+	presencebox->uid = 9;
 	/*for(int i = 0; i < 0; i++){
 		char line[256];
 		sprintf(line, "line %d", i);
@@ -3156,6 +3190,7 @@ Interface * Game::CreateChatInterface(void){
 	chatinterface->AddObject(chatinputborder->id);
 	chatinterface->AddObject(channeltext->id);
 	chatinterface->AddObject(textbox->id);
+	chatinterface->AddObject(presencebox->id);
 	chatinterface->AddObject(chatinput->id);
 	chatinterface->AddObject(chatscrollbar->id);
 	chatinterface->AddTabObject(chatinput->id);
@@ -4351,6 +4386,43 @@ bool Game::ProcessLobbyInterface(Interface * iface){
 				}break;
 				case ObjectTypes::TEXTBOX:{
 					TextBox * textbox = static_cast<TextBox *>(object);
+					if(textbox && textbox->uid == 9){
+						if(world.lobby.presencechanged || !world.lobby.gamesprocessed){
+							textbox->text.clear();
+							textbox->scrolled = 0;
+							struct Row { Uint8 group; std::string label; };
+							std::vector<Row> rows;
+							for(auto & kv : world.lobby.presence){
+								Lobby::PresenceEntry & e = kv.second;
+								Row r;
+								r.label = e.name;
+								r.group = (e.status <= 2) ? e.status : 0;
+								if(e.gameid != 0){
+									LobbyGame * g = world.lobby.GetGameById(e.gameid);
+									if(g){
+										r.label += " [";
+										r.label += g->name;
+										r.label += "]";
+									}
+								}
+								rows.push_back(r);
+							}
+							std::sort(rows.begin(), rows.end(), [](const Row & a, const Row & b){
+								if(a.group != b.group) return a.group < b.group;
+								return a.label < b.label;
+							});
+							Uint8 lastgroup = 255;
+							for(auto & r : rows){
+								if(r.group != lastgroup){
+									const char * header = (r.group == 0) ? "In Lobby" : (r.group == 1) ? "Pregame" : "Playing";
+									textbox->AddText(header, 0, 128 + 32, 0, false);
+									lastgroup = r.group;
+								}
+								textbox->AddText(r.label.c_str(), 0, 128, 2, false);
+							}
+							world.lobby.presencechanged = false;
+						}
+					}else
 					if(textbox){
 						Object * object = world.GetObjectFromId(iface->scrollbar);
 						ScrollBar * scrollbar = static_cast<ScrollBar *>(object);

--- a/src/game.h
+++ b/src/game.h
@@ -139,6 +139,8 @@ private:
 	Uint8 singleplayermessage;
 	bool updatetitle;
 	Uint32 currentlobbygameid;
+	Uint32 lastannouncedgameid;
+	Uint8 lastannouncedstatus;
 	char lastchannel[64];
 	Uint8 oldselectedagency;
 	Uint8 oldambiencelevel;

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -15,6 +15,7 @@ Lobby::Lobby(World * world){
 	connectgamestatus = 0;
 	sendbufferoffset = 0;
 	gamesprocessed = false;
+	presencechanged = false;
 	channelchanged = false;
 	channel[0] = 0;
 	serverip[0] = 0;
@@ -69,6 +70,8 @@ void Lobby::Disconnect(void){
 	}
 	sendbuffersize = 0;
 	sendbufferoffset = 0;
+	presence.clear();
+	presencechanged = true;
     shutdown(sockethandle, SHUT_RDWR);
     closesocket(sockethandle);
 	sockethandle = -1;
@@ -191,8 +194,17 @@ void Lobby::DoNetwork(void){
 									lobbygame->createdtime = SDL_GetTicks();
 									lobbygame->Serialize(Serializer::READ, data);
 									//printf("password: %s\n", lobbygame->password);
+									for(std::list<LobbyGame *>::iterator dit = games.begin(); dit != games.end(); ){
+										if((*dit)->id == lobbygame->id){
+											delete *dit;
+											dit = games.erase(dit);
+										}else{
+											++dit;
+										}
+									}
 									games.push_back(lobbygame);
 									gamesprocessed = false;
+									presencechanged = true;
 									if(lobbygame->accountid == Lobby::accountid){ // CreateGame response
 										Lobby::creategamestatus = creategamestatus;
 										if(creategamestatus == 1){ // success
@@ -215,6 +227,7 @@ void Lobby::DoNetwork(void){
 											delete lobbygame;
 											games.erase(it);
 											gamesprocessed = false;
+											presencechanged = true;
 											break;
 										}
 									}
@@ -333,6 +346,36 @@ void Lobby::DoNetwork(void){
 									ForgetUserInfo(accountid);
 									GetUserInfo(accountid)->statsagency = oldstatsagency;
 									statupgraded = true;
+								}break;
+								case MSG_PRESENCE:{
+									Uint8 action;
+									data.Get(action);
+									Uint32 acct;
+									data.Get(acct);
+									Uint32 gid;
+									data.Get(gid);
+									Uint8 status;
+									data.Get(status);
+									Uint8 namelen;
+									data.Get(namelen);
+									if(namelen > 16){
+										namelen = 16;
+									}
+									char name[17];
+									for(Uint8 i = 0; i < namelen; i++){
+										data.Get(name[i]);
+									}
+									name[namelen] = 0;
+									if(action == 0){
+										PresenceEntry & e = presence[acct];
+										e.accountid = acct;
+										e.gameid = gid;
+										e.status = status;
+										strcpy(e.name, name);
+									}else{
+										presence.erase(acct);
+									}
+									presencechanged = true;
 								}break;
 							}
 							msgsize = 0;
@@ -467,6 +510,15 @@ void Lobby::CreateGame(const char * name, const char * map, const unsigned char 
 	SendMessage(data.data, data.BitsToBytes(data.offset));
 	printf("requested thru lobby server to connect to game id %d, (ports %d,%d) agency %d\n", lobbygame.accountid, port, publicport, agency);
 }*/
+
+void Lobby::SendSetGame(Uint32 gameid, Uint8 status){
+	Serializer data;
+	Uint8 code = MSG_SETGAME;
+	data.Put(code);
+	data.Put(gameid);
+	data.Put(status);
+	SendMessage(data.data, data.BitsToBytes(data.offset));
+}
 
 void Lobby::ClearGames(void){
 	for(std::list<LobbyGame *>::iterator it = games.begin(); it != games.end(); it++){

--- a/src/lobby.h
+++ b/src/lobby.h
@@ -20,7 +20,13 @@ public:
 	void LockMutex(void);
 	void UnlockMutex(void);
 	enum {IDLE, WAITING, CONNECTING, RESOLVING, WAITINGFORRESOLVER, RESOLVED, RESOLVEFAILED, CONNECTIONFAILED, CONNECTED, CHECKINGVERSION, AUTHENTICATING, AUTHSENT, AUTHENTICATED, AUTHFAILED, DISCONNECTED} state;
-	enum {MSG_AUTH, MSG_MOTD, MSG_CHAT, MSG_NEWGAME, MSG_DELGAME, MSG_CHANNEL, MSG_CONNECT, MSG_VERSION, MSG_USERINFO, MSG_PING, MSG_UPGRADESTAT, MSG_REGISTERSTATS};
+	enum {MSG_AUTH, MSG_MOTD, MSG_CHAT, MSG_NEWGAME, MSG_DELGAME, MSG_CHANNEL, MSG_CONNECT, MSG_VERSION, MSG_USERINFO, MSG_PING, MSG_UPGRADESTAT, MSG_REGISTERSTATS, MSG_PRESENCE, MSG_SETGAME};
+	struct PresenceEntry {
+		Uint32 accountid;
+		Uint32 gameid; // 0 = main lobby
+		Uint8 status;  // 0 = lobby, 1 = pregame, 2 = playing
+		char name[17]; // matches server-side max username (16) + null
+	};
 	void SendVersion(void);
 	void SendCredentials(const char * username, const char * password);
 	void SendChat(const char * channel, const char * message);
@@ -34,6 +40,7 @@ public:
 	void ForgetAllUserInfo(void);
 	void UpgradeStat(Uint8 agency, Uint8 stat);
 	void RegisterStats(User & user, Uint8 won, Uint32 gameid);
+	void SendSetGame(Uint32 gameid, Uint8 status);
 	char failmessage[256];
 	Uint32 accountid;
 	char motd[2048];
@@ -44,6 +51,8 @@ public:
 	std::list<std::vector<char>> chatmessages;
 	std::list<LobbyGame *> games;
 	bool gamesprocessed;
+	std::map<Uint32, PresenceEntry> presence;
+	bool presencechanged;
 	char channel[64];
 	bool channelchanged;
 	char serverip[256];

--- a/src/textbox.cpp
+++ b/src/textbox.cpp
@@ -2,6 +2,7 @@
 #include "interface.h"
 
 TextBox::TextBox() : Object(ObjectTypes::TEXTBOX){
+	uid = 0;
 	res_bank = 133;
 	res_index = 0xFF;
 	lineheight = 11;

--- a/src/textbox.h
+++ b/src/textbox.h
@@ -14,6 +14,7 @@ public:
 	void Tick(World & world);
 	void AddLine(const char * string, Uint8 color = 0, Uint8 brightness = 128, bool scroll = true);
 	void AddText(const char * string, Uint8 color = 0, Uint8 brightness = 128, int indent = 0, bool scroll = true);
+	Uint8 uid;
 	Uint8 lineheight;
 	Uint8 fontwidth;
 	Uint16 width;


### PR DESCRIPTION
## Summary
- Adds a presence sidebar to the lobby chat interface showing who's signed in, grouped by In Lobby / Pregame / Playing
- New protocol opcodes `opPresence` (12) and `opSetGame` (13); client version bumped 00023 → 00024

## Test plan
- [ ] Sign in with two clients against a local lobby; each sees the other in the sidebar
- [ ] Join a game → other client sees status flip to Pregame, then Playing on match start
- [ ] Disconnect → entry disappears on peers

🤖 Generated with [Claude Code](https://claude.com/claude-code)